### PR TITLE
Cleanup and rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+  - improved error messages
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +258,7 @@ name = "cargo-certora-sbf"
 version = "0.2.0"
 dependencies = [
  "assert_cmd",
+ "assert_fs",
  "bzip2",
  "cargo_metadata",
  "clap",
@@ -256,7 +272,6 @@ dependencies = [
  "reqwest 0.12.15",
  "semver",
  "serde_json",
- "serial_test",
  "solana-file-download",
  "tar",
  "which",
@@ -411,6 +426,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,21 +592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,17 +606,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -611,7 +631,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -654,6 +673,30 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.9.0",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "h2"
@@ -988,6 +1031,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,16 +1166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,29 +1238,6 @@ name = "once_cell"
 version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1663,19 +1689,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "scc"
-version = "2.3.3"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "sdd",
+ "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1686,12 +1706,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "semver"
@@ -1744,31 +1758,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1899,6 +1888,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix 1.0.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2109,6 +2111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2260,15 @@ dependencies = [
  "env_home",
  "rustix 0.38.44",
  "winsafe",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "clap-cargo",
  "clap-verbosity-flag",
  "env_logger",
+ "home",
  "itertools",
  "log",
  "predicates",
@@ -728,6 +729,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ which = "7.0.2"
 serde_json = "1"
 clap-verbosity-flag = "3.0.2"
 env_logger = "0.11.8"
+home = "0.5.11"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ env_logger = "0.11.8"
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.1.3"
-serial_test = "3.2.0"
+assert_fs = "1.1.2"
 
 [features]
 program = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -868,9 +868,12 @@ fn main() {
 
     // setup log level
     env_logger::builder()
-        // .format(|buf, record| writeln!(buf, "{}: {}", record.level(), record.args()))
-        .format_timestamp(None)
-        .format_target(false)
+        .format(|buf, record| {
+            let level = record.level();
+            let style = buf.default_level_style(level);
+            let level = level.to_string().to_lowercase();
+            writeln!(buf, "{style}{}{style:#}: {}", level, record.args())
+        })
         .filter_level(args.verbose.log_level_filter())
         .init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,12 +336,6 @@ struct CertoraSbfArgs {
         default_value_os_t = default_platform_tools_root(),
     )]
     platform_tools_root: PathBuf,
-    #[arg(
-        long,
-        env = "SBF_OUT_PATH",
-        help = "Output directory for build artifacts"
-    )]
-    sbf_out_dir: Option<PathBuf>,
     #[arg(long, help = "Additional arguments to pass to cargo")]
     cargo_args: Option<Vec<String>>,
     #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,8 +337,8 @@ struct CertoraSbfArgs {
     #[arg(long, help = "Generate shell script on failure for debugging")]
     generate_child_script_on_failure: bool,
     #[arg(
-        long, 
-        default_value_t = DEFAULT_PLATFORM_TOOLS_VERSION.to_string(), 
+        long,
+        default_value_t = DEFAULT_PLATFORM_TOOLS_VERSION.to_string(),
         id = "tools_version",
         value_name = "VERSION",
         help = "Platform tools version to use")]
@@ -860,7 +860,7 @@ fn main() {
         }
     }
 
-   let CertoraSbfCargoCli::CertoraSbf(mut args) = CertoraSbfCargoCli::from_arg_matches(&matches)
+    let CertoraSbfCargoCli::CertoraSbf(mut args) = CertoraSbfCargoCli::from_arg_matches(&matches)
         .unwrap_or_else(|e| {
             e.exit();
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 use {
     bzip2::bufread::BzDecoder,
     cargo_metadata::{camino::Utf8Path, CrateType, Metadata, MetadataCommand, Package, Target},
-    clap::Parser,
+    clap::{parser::ValueSource, CommandFactory, FromArgMatches, Parser},
     clap_verbosity_flag::VerbosityFilter,
     itertools::Itertools,
     log::{debug, error, info},
@@ -849,7 +849,22 @@ impl CertoraSbfArgs {
 }
 
 fn main() {
-    let CertoraSbfCargoCli::CertoraSbf(mut args) = CertoraSbfCargoCli::parse();
+    let cmd = CertoraSbfCargoCli::command();
+    let matches = cmd.get_matches();
+
+    if let Some((_name, matches)) = matches.subcommand() {
+        if matches.value_source(&"tools_version") == Some(ValueSource::DefaultValue) {
+            println!("source for tools version is default");
+        } else {
+            println!("tools version is explicitly requested");
+        }
+    }
+
+   let CertoraSbfCargoCli::CertoraSbf(mut args) = CertoraSbfCargoCli::from_arg_matches(&matches)
+        .unwrap_or_else(|e| {
+            e.exit();
+        });
+    // let CertoraSbfCargoCli::CertoraSbf(mut args) = CertoraSbfCargoCli::parse();
 
     // setup log level
     env_logger::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,12 @@ struct CertoraSbfArgs {
     no_rustup_override: bool,
     #[arg(long, help = "Generate shell script on failure for debugging")]
     generate_child_script_on_failure: bool,
-    #[arg(long, default_value_t = DEFAULT_PLATFORM_TOOLS_VERSION.to_string(), help = "Platform tools version to use")]
+    #[arg(
+        long, 
+        default_value_t = DEFAULT_PLATFORM_TOOLS_VERSION.to_string(), 
+        id = "tools_version",
+        value_name = "VERSION",
+        help = "Platform tools version to use")]
     tools_version: String,
     #[arg(long, short, help = "Number of parallel jobs")]
     jobs: Option<usize>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 use {
     bzip2::bufread::BzDecoder,
     cargo_metadata::{camino::Utf8Path, CrateType, Metadata, MetadataCommand, Package, Target},
-    clap::{parser::ValueSource, CommandFactory, FromArgMatches, Parser},
+    clap::{CommandFactory, FromArgMatches, Parser},
     clap_verbosity_flag::VerbosityFilter,
     itertools::Itertools,
     log::{debug, error, info},
@@ -881,13 +881,14 @@ fn main() {
     let cmd = CertoraSbfCargoCli::command();
     let matches = cmd.get_matches();
 
-    if let Some((_name, matches)) = matches.subcommand() {
-        if matches.value_source(&"tools_version") == Some(ValueSource::DefaultValue) {
-            println!("source for tools version is default");
-        } else {
-            println!("tools version is explicitly requested");
-        }
-    }
+    // if let Some((_name, matches)) = matches.subcommand() {
+    //     use clap::parser::ValueSource;
+    //     if matches.value_source(&"tools_version") == Some(ValueSource::DefaultValue) {
+    //         println!("source for tools version is default");
+    //     } else {
+    //         println!("tools version is explicitly requested");
+    //     }
+    // }
 
     let CertoraSbfCargoCli::CertoraSbf(mut args) = CertoraSbfCargoCli::from_arg_matches(&matches)
         .unwrap_or_else(|e| {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,7 @@
+use std::path::PathBuf;
+
 use assert_cmd::Command;
-//use assert_fs::prelude::*;
+use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 #[test]
@@ -12,47 +14,55 @@ fn test_help() {
         .stdout(predicate::str::contains("Usage"));
 }
 
-// Needs more thought
-// #[test]
-// fn test_on_temp_project() {
-//     // Create a temporary directory
-//     let temp = assert_fs::TempDir::new().unwrap();
+#[test]
+fn test_on_test_project() {
+    // Create a temporary directory
+    let temp = assert_fs::TempDir::new().unwrap();
+    let temp = temp.into_persistent();
 
-//     // Create a minimal Cargo project inside it
-//     temp.child("Cargo.toml")
-//         .write_str(
-//             r#"
-//         [package]
-//         name = "temp_proj"
-//         version = "0.1.0"
-//         edition = "2021"
-//         [lib]
-//         crate-type = ["cdylib"]
-//         name = "temp_proj"
-//         [features]
-//         certora = []
-//     "#,
-//         )
-//         .unwrap();
+    // Create a minimal Cargo project inside it
+    temp.child("Cargo.toml")
+        .write_str(
+            r#"
+[package]
+name = "test_proj"
+version = "0.1.0"
+edition = "2021"
+[lib]
+crate-type = ["cdylib"]
+name = "test_proj"
+[features]
+certora = []
+    "#,
+        )
+        .unwrap();
 
-//     temp.child("src/lib.rs")
-//         .write_str(
-//             r#"
-//         #[no_mangle]
-//         pub fn foo () {
-//             println!("Hello, world!");
-//         }
-//     "#,
-//         )
-//         .unwrap();
+    temp.child("src/lib.rs")
+        .write_str(
+            r#"
+        #[no_mangle]
+        pub fn foo () {
+            println!("Hello, world!");
+        }
+    "#,
+        )
+        .unwrap();
 
-//     // Run the subcommand inside the temp project
-//     let mut cmd = Command::cargo_bin("cargo-certora-sbf").unwrap();
-//     cmd.current_dir(temp.path())
-//         .assert()
-//         .success()
-//         .stdout(predicate::str::contains("expected output"));
+    // Run the subcommand inside the temp project
+    let mut cmd = Command::cargo_bin("cargo-certora-sbf").unwrap();
+    let cmd_path = PathBuf::from(cmd.get_program());
+    let tools_root_path = cmd_path.parent().unwrap().join("certora-tools-root");
+    let platform_tools_root_arg = format!("--platform-tools-root={}", tools_root_path.to_string_lossy());
+    cmd.arg("certora-sbf")
+        .arg("--no-rustup")
+        .arg("-vv")
+        .arg(&platform_tools_root_arg)
+        .current_dir(temp.path())
+        .env_clear()
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Finished release"));
 
-//     // Cleanup
-//     temp.close().unwrap();
-// }
+    // Cleanup
+    temp.close().unwrap();
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -52,7 +52,10 @@ certora = []
     let mut cmd = Command::cargo_bin("cargo-certora-sbf").unwrap();
     let cmd_path = PathBuf::from(cmd.get_program());
     let tools_root_path = cmd_path.parent().unwrap().join("certora-tools-root");
-    let platform_tools_root_arg = format!("--platform-tools-root={}", tools_root_path.to_string_lossy());
+    let platform_tools_root_arg = format!(
+        "--platform-tools-root={}",
+        tools_root_path.to_string_lossy()
+    );
     cmd.arg("certora-sbf")
         .arg("--no-rustup")
         .arg("-vv")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,58 @@
+use assert_cmd::Command;
+//use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn test_help() {
+    let mut cmd = Command::cargo_bin("cargo-certora-sbf").unwrap();
+    cmd.arg("certora-sbf")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Usage"));
+}
+
+// Needs more thought
+// #[test]
+// fn test_on_temp_project() {
+//     // Create a temporary directory
+//     let temp = assert_fs::TempDir::new().unwrap();
+
+//     // Create a minimal Cargo project inside it
+//     temp.child("Cargo.toml")
+//         .write_str(
+//             r#"
+//         [package]
+//         name = "temp_proj"
+//         version = "0.1.0"
+//         edition = "2021"
+//         [lib]
+//         crate-type = ["cdylib"]
+//         name = "temp_proj"
+//         [features]
+//         certora = []
+//     "#,
+//         )
+//         .unwrap();
+
+//     temp.child("src/lib.rs")
+//         .write_str(
+//             r#"
+//         #[no_mangle]
+//         pub fn foo () {
+//             println!("Hello, world!");
+//         }
+//     "#,
+//         )
+//         .unwrap();
+
+//     // Run the subcommand inside the temp project
+//     let mut cmd = Command::cargo_bin("cargo-certora-sbf").unwrap();
+//     cmd.current_dir(temp.path())
+//         .assert()
+//         .success()
+//         .stdout(predicate::str::contains("expected output"));
+
+//     // Cleanup
+//     temp.close().unwrap();
+// }


### PR DESCRIPTION
Started as a cleanup, but ended up with a significant rewrite.

* No longer requires Rustup (but can use it if required) (`--no-rustup`)
* Can install tools without building a project (`--no-build`)
* User controlled install directory (`--platform-tools-root <PATH>`)
* Skip tool installation (`--no-tools-install`)
* Depends only on `cargo` and `rustc` that are bundled into platform tools
* Rudimentary test
* More informative and prettier error messages and verbose mode
* Cleanup internal logic