### PR TITLE
Always add flag -Zremap-cwd-prefix to rust flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+  - `-Zremap-cwd-prefix` flag is always used to compile projects
+
+### Removed
+  - remove command line flag `remap_cwd`
+
 ## [0.3.1] - 2025-04-18
  ### Changed
   - fix handling of platform-tools-root for non-default version of tools

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,8 +335,6 @@ struct CertoraSbfArgs {
     platform_tools_root: PathBuf,
     #[arg(long, help = "Additional arguments to pass to cargo")]
     cargo_args: Option<Vec<String>>,
-    #[arg(long)]
-    remap_cwd: bool,
     #[arg(long, help = "Enable debug information in compiled binary")]
     debug: bool,
     #[arg(long, help = "Force fresh install of platform tools")]
@@ -747,9 +745,10 @@ impl CertoraSbfArgs {
         rust_flags.add_from_env("RUSTFLAGS");
         rust_flags.add_from_env(&cargo_target_rustflags);
 
-        if self.remap_cwd && !self.debug {
-            rust_flags.add_flag("-Zremap-cwd-prefix=");
-        }
+        // Adds the -Zremap-cwd-prefix flag to disable remapping of the current
+        // working directory's prefix, ensuring paths remain unchanged or
+        // relative during compilation.
+        rust_flags.add_flag("-Zremap-cwd-prefix=");
 
         if self.debug {
             // Replace with -Zsplit-debuginfo=packed when stabilized.


### PR DESCRIPTION
In this PR we always add `-Zremap-cwd-prefix` to Rust flags.
I removed the `remap-cwd` flag and bumped the version.